### PR TITLE
Prevent textdomain from loading before init

### DIFF
--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -59,7 +59,7 @@ final class Plugin {
      * @since 1.1.0 Changes Shortcode constant to Types.
      */
     protected function define_constants() {
-        define( 'ANYS_NAME', esc_html__( 'Anything Shortcodes', 'anys' ) );
+        define( 'ANYS_NAME', 'Anything Shortcodes' );
         define( 'ANYS_SLUG', 'anys' );
         define( 'ANYS_VERSION', '1.4.0' );
 


### PR DESCRIPTION
### Summary
This patch fixes the `_load_textdomain_just_in_time` notice in WordPress 6.7+.

### Details
The constant `ANYS_NAME` was defined using `esc_html__()` inside `define_constants()`, which triggered translation too early, before the `init` action.
This caused WordPress to log a warning about early textdomain loading.

### Fix
Replaced the translated constant with a plain string:
```php
define( 'ANYS_NAME', 'Anything Shortcodes' );
```