### PR TITLE
Add spoiler shortcode (SpoilerJS) with license and temporary module fix

### DIFF
--- a/includes/modules/assets/assets.php
+++ b/includes/modules/assets/assets.php
@@ -24,6 +24,8 @@ final class Assets {
     protected function add_hooks() {
         add_action( 'init', [ $this, 'register_assets' ] );
         add_action( 'wp_head', [ $this, 'localize_data' ] );
+
+        add_filter( 'script_loader_tag', [ $this, 'force_module_type' ], 9999, 3 );
     }
 
     /**
@@ -47,6 +49,14 @@ final class Assets {
                     'deps'      => [],
                     'version'   => ANYS_VERSION,
                     'in_footer' => true,
+                    'is_module' => false,
+                ],
+                'anys-spoilerjs' => [
+                    'src'       => ANYS_ASSETS_URL . 'vendor/spoilerjs/spoiler-span.js',
+                    'deps'      => [],
+                    'version'   => ANYS_VERSION,
+                    'in_footer' => true,
+                    'is_module' => true,
                 ],
             ],
         ];
@@ -85,7 +95,12 @@ final class Assets {
                     $script['version'] ?? false,
                     $script['in_footer'] ?? true
                 );
+
+                if ( ! empty( $script['is_module'] ) && $script['is_module'] ) {
+                    wp_script_add_data( $handle, 'type', 'module' );
+                }
             }
+
         }
     }
 
@@ -103,6 +118,21 @@ final class Assets {
             ] ); ?>;
         </script>
         <?php
+    }
+
+    /**
+     * Force type="module" for spoilerjs handle.
+     *
+     * @since NEXT
+     */
+    public function force_module_type( $tag, $handle, $src ) {
+        if ( $handle === 'anys-spoilerjs' ) {
+            // If type attr is missing, inject it.
+            if ( strpos( $tag, ' type=' ) === false ) {
+                $tag = str_replace( '<script ', '<script type="module" ', $tag );
+            }
+        }
+        return $tag;
     }
 }
 

--- a/includes/modules/assets/assets.php
+++ b/includes/modules/assets/assets.php
@@ -123,6 +123,8 @@ final class Assets {
     /**
      * Force type="module" for spoilerjs handle.
      *
+     * @todo Remove once core script data reliably sets type="module".
+     *
      * @since NEXT
      */
     public function force_module_type( $tag, $handle, $src ) {

--- a/includes/modules/assets/assets.php
+++ b/includes/modules/assets/assets.php
@@ -54,7 +54,7 @@ final class Assets {
                 'anys-spoilerjs' => [
                     'src'       => ANYS_ASSETS_URL . 'vendor/spoilerjs/spoiler-span.js',
                     'deps'      => [],
-                    'version'   => ANYS_VERSION,
+                    'version'   => '0.2.0',
                     'in_footer' => true,
                     'is_module' => true,
                 ],

--- a/includes/modules/shortcodes/shortcodes.php
+++ b/includes/modules/shortcodes/shortcodes.php
@@ -78,7 +78,7 @@ final class Shortcodes {
         }
 
         // Bails early if no type or name is provided.
-        if ( empty( $attributes['type'] ) || empty( $attributes['name'] ) ) {
+        if ( empty( $attributes['type'] ) && empty( $attributes['name'] ) ) {
             return '';
         }
 

--- a/includes/modules/shortcodes/types/spoiler.php
+++ b/includes/modules/shortcodes/types/spoiler.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace AnyS\Modules\Shortcodes\Types;
+
+defined( 'ABSPATH' ) || exit;
+
+use AnyS\Traits\Singleton;
+
+/**
+ * Defines the Spoiler shortcode type.
+ *
+ * Handles `[anys type="spoiler"]...[/anys]`.
+ *
+ * @since NEXT
+ */
+final class Spoiler_Type extends Base {
+    use Singleton;
+
+    /**
+     * Returns the shortcode identifier.
+     *
+     * @since NEXT
+     */
+    public function get_type() {
+        return 'spoiler';
+    }
+
+    /**
+     * Provides default attributes.
+     *
+     * Supports all SpoilerJS options.
+     *
+     * @since NEXT
+     */
+    protected function get_defaults() {
+        return [
+            'before'             => '',
+            'after'              => '',
+            'fallback'           => '',
+            'format'             => '',
+            'scale'              => '',
+            'min-velocity'       => '',
+            'max-velocity'       => '',
+            'particle-lifetime'  => '',
+            'density'            => '',
+            'reveal-duration'    => '',
+            'spawn-stop-delay'   => '',
+            'monitor-position'   => '',
+            'fps'                => '',
+        ];
+    }
+
+    /**
+     * Generates the shortcode output.
+     *
+     * @since NEXT
+     */
+    public function render( array $attributes, string $content = '' ) {
+        $attributes = $this->get_attributes( $attributes );
+        $attributes = anys_parse_dynamic_attributes( $attributes );
+
+        // Loads the SpoilerJS script on frontend.
+        if ( ! is_admin() ) {
+            wp_enqueue_script( 'anys-spoilerjs' );
+        }
+
+        // Builds attribute string.
+        $keys = [
+            'scale','min-velocity','max-velocity','particle-lifetime',
+            'density','reveal-duration','spawn-stop-delay',
+            'monitor-position','fps',
+        ];
+
+        $html_attrs = '';
+        foreach ( $keys as $key ) {
+            if ( isset( $attributes[ $key ] ) && $attributes[ $key ] !== '' ) {
+                $html_attrs .= sprintf(
+                    ' %s="%s"',
+                    esc_attr( $key ),
+                    esc_attr( (string) $attributes[ $key ] )
+                );
+            }
+        }
+
+        // Processes content.
+        $inner = wp_kses_post( do_shortcode( $content ) );
+
+        // Creates <spoiler-span> element.
+        $spoiler = sprintf( '<spoiler-span%s>%s</spoiler-span>', $html_attrs, $inner );
+
+        // Applies wrappers and formatting.
+        $spoiler = anys_format_value( $spoiler, $attributes );
+        $output  = anys_wrap_output( $spoiler, $attributes );
+
+        // Allows spoiler-span attributes.
+        $allowed = wp_kses_allowed_html( 'post' );
+        $allowed['spoiler-span'] = [
+            'scale'             => true,
+            'min-velocity'      => true,
+            'max-velocity'      => true,
+            'particle-lifetime' => true,
+            'density'           => true,
+            'reveal-duration'   => true,
+            'spawn-stop-delay'  => true,
+            'monitor-position'  => true,
+            'fps'               => true,
+        ];
+
+        return wp_kses( (string) $output, $allowed );
+    }
+}

--- a/includes/modules/shortcodes/types/spoiler.php
+++ b/includes/modules/shortcodes/types/spoiler.php
@@ -20,6 +20,8 @@ final class Spoiler_Type extends Base {
      * Returns the shortcode identifier.
      *
      * @since NEXT
+     *
+     * @return string
      */
     public function get_type() {
         return 'spoiler';
@@ -31,22 +33,24 @@ final class Spoiler_Type extends Base {
      * Supports all SpoilerJS options.
      *
      * @since NEXT
+     *
+     * @return array
      */
     protected function get_defaults() {
         return [
-            'before'             => '',
-            'after'              => '',
-            'fallback'           => '',
-            'format'             => '',
-            'scale'              => '',
-            'min-velocity'       => '',
-            'max-velocity'       => '',
-            'particle-lifetime'  => '',
-            'density'            => '',
-            'reveal-duration'    => '',
-            'spawn-stop-delay'   => '',
-            'monitor-position'   => '',
-            'fps'                => '',
+            'before' => '',
+            'after' => '',
+            'fallback' => '',
+            'format' => '',
+            'scale' => '',
+            'min-velocity' => '',
+            'max-velocity' => '',
+            'particle-lifetime' => '',
+            'density' => '',
+            'reveal-duration' => '',
+            'spawn-stop-delay' => '',
+            'monitor-position' => '',
+            'fps' => '',
         ];
     }
 
@@ -54,6 +58,11 @@ final class Spoiler_Type extends Base {
      * Generates the shortcode output.
      *
      * @since NEXT
+     *
+     * @param array  $attributes Raw shortcode attributes.
+     * @param string $content    Shortcode content.
+     *
+     * @return string
      */
     public function render( array $attributes, string $content = '' ) {
         $attributes = $this->get_attributes( $attributes );
@@ -66,44 +75,57 @@ final class Spoiler_Type extends Base {
 
         // Builds attribute string.
         $keys = [
-            'scale','min-velocity','max-velocity','particle-lifetime',
-            'density','reveal-duration','spawn-stop-delay',
-            'monitor-position','fps',
+            'scale',
+            'min-velocity',
+            'max-velocity',
+            'particle-lifetime',
+            'density',
+            'reveal-duration',
+            'spawn-stop-delay',
+            'monitor-position',
+            'fps',
         ];
 
         $html_attrs = '';
+
         foreach ( $keys as $key ) {
-            if ( isset( $attributes[ $key ] ) && $attributes[ $key ] !== '' ) {
-                $html_attrs .= sprintf(
-                    ' %s="%s"',
-                    esc_attr( $key ),
-                    esc_attr( (string) $attributes[ $key ] )
-                );
+            if ( ! isset( $attributes[ $key ] ) || $attributes[ $key ] === '' ) {
+                continue;
             }
+
+            $html_attrs .= sprintf(
+                ' %s="%s"',
+                esc_attr( $key ),
+                esc_attr( (string) $attributes[ $key ] )
+            );
         }
 
         // Processes content.
         $inner = wp_kses_post( do_shortcode( $content ) );
 
         // Creates <spoiler-span> element.
-        $spoiler = sprintf( '<spoiler-span%s>%s</spoiler-span>', $html_attrs, $inner );
+        $spoiler = sprintf(
+            '<spoiler-span%s>%s</spoiler-span>',
+            $html_attrs,
+            $inner
+        );
 
         // Applies wrappers and formatting.
         $spoiler = anys_format_value( $spoiler, $attributes );
-        $output  = anys_wrap_output( $spoiler, $attributes );
+        $output = anys_wrap_output( $spoiler, $attributes );
 
         // Allows spoiler-span attributes.
         $allowed = wp_kses_allowed_html( 'post' );
         $allowed['spoiler-span'] = [
-            'scale'             => true,
-            'min-velocity'      => true,
-            'max-velocity'      => true,
+            'scale' => true,
+            'min-velocity' => true,
+            'max-velocity' => true,
             'particle-lifetime' => true,
-            'density'           => true,
-            'reveal-duration'   => true,
-            'spawn-stop-delay'  => true,
-            'monitor-position'  => true,
-            'fps'               => true,
+            'density' => true,
+            'reveal-duration' => true,
+            'spawn-stop-delay' => true,
+            'monitor-position' => true,
+            'fps' => true,
         ];
 
         return wp_kses( (string) $output, $allowed );

--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -147,6 +147,7 @@ final class Plugin {
             'shortcodes/shortcodes.php',
             'nav-menu/nav-menu.php',
             'elementor/elementor.php',
+            'assets/assets.php',
         ];
 
         foreach ( $modules as $module ) {


### PR DESCRIPTION
### Summary
Added a new `[anys type="spoiler"]` shortcode powered by the SpoilerJS web component.
This allows displaying spoiler effects in frontend content.

### Changes
- Added **Spoiler_Type** class for `[anys type="spoiler"]...[/anys]`.
- Integrated **SpoilerJS** under `assets/vendor/spoilerjs/` with all supporting chunks.
- Registered SpoilerJS as an ES module script in the Assets module.
- Implemented a temporary method `force_module_type()` to ensure `type="module"` until a cleaner handling is added.
- Included **SpoilerJS LICENSE** (MIT) file for proper attribution.
- Enabled all SpoilerJS attributes (`density`, `scale`, `reveal-duration`, etc.) as shortcode parameters.
- Allowed `<spoiler-span>` tag and its attributes in KSES sanitization.

### Notes
- The current `force_module_type()` filter is a temporary solution for cases where the module type isn’t respected by WordPress or caching plugins.  
  A more robust native handling will be added later.

### Result
- `[anys type="spoiler"]Spoiler content[/anys]` now renders correctly with animation effects.
- Script loads only on frontend pages where the shortcode appears.
- Licensing for SpoilerJS is properly included.
