### PR TITLE
Fix function shortcode errors caused by missing arguments

### DIFF
--- a/includes/modules/shortcodes/types/function.php
+++ b/includes/modules/shortcodes/types/function.php
@@ -119,8 +119,12 @@ final class Function_Type extends Base {
             )
         );
 
-        // Executes target function.
-        $value = call_user_func_array( $function, $args );
+        try {
+            // Executes target function.
+            $value = call_user_func_array( $function, $args );
+        } catch ( \Throwable ) {
+            $value = '';
+        }
 
         // Formats and wraps.
         $value  = anys_format_value( $value, $attributes );


### PR DESCRIPTION
Prevents editor-breaking fatal errors by safely wrapping function shortcode execution in a try/catch block. Ensures missing arguments no longer crash render and the editor always loads properly.