### PR TITLE
Add type hinting across project

### DIFF
--- a/includes/modules/ajax/ajax.php
+++ b/includes/modules/ajax/ajax.php
@@ -21,7 +21,7 @@ final class Ajax {
      *
      * @since NEXT
      */
-    protected function add_hooks() {
+    protected function add_hooks(): void {
         add_action( 'wp_ajax_anys', [ $this, 'handle_request' ] );
         add_action( 'wp_ajax_nopriv_anys', [ $this, 'handle_request' ] );
     }
@@ -31,7 +31,7 @@ final class Ajax {
      *
      * @since NEXT
      */
-    public function handle_request() {
+    public function handle_request(): void {
         // Verifies the nonce.
         check_ajax_referer( 'anys_nonce' );
 

--- a/includes/modules/assets/assets.php
+++ b/includes/modules/assets/assets.php
@@ -21,7 +21,7 @@ final class Assets {
      *
      * @since NEXT
      */
-    protected function add_hooks() {
+    protected function add_hooks(): void {
         add_action( 'init', [ $this, 'register_assets' ] );
         add_action( 'wp_head', [ $this, 'localize_data' ] );
 
@@ -33,7 +33,7 @@ final class Assets {
      *
      * @since NEXT
      */
-    protected function get_assets() {
+    protected function get_assets(): array {
         $assets = [
             'styles' => [
                 'anys-utilities' => [
@@ -69,7 +69,7 @@ final class Assets {
      *
      * @since NEXT
      */
-    public function register_assets() {
+    public function register_assets(): void {
         $assets = $this->get_assets();
 
         // Registers styles.
@@ -109,7 +109,7 @@ final class Assets {
      *
      * @since NEXT
      */
-    public function localize_data() {
+    public function localize_data(): void {
         ?>
         <script>
             window.anysData = <?php echo wp_json_encode( [
@@ -127,7 +127,7 @@ final class Assets {
      *
      * @since NEXT
      */
-    public function force_module_type( $tag, $handle, $src ) {
+    public function force_module_type( string $tag, string $handle, string $src ): string {
         if ( $handle === 'anys-spoilerjs' ) {
             // If type attr is missing, inject it.
             if ( strpos( $tag, ' type=' ) === false ) {

--- a/includes/modules/elementor/shortcode-tag.php
+++ b/includes/modules/elementor/shortcode-tag.php
@@ -20,7 +20,7 @@ final class Shortcode_Tag extends Tag {
      *
      * @return string
      */
-    public function get_name() {
+    public function get_name(): string {
         return 'anys-shortcode';
     }
 
@@ -29,7 +29,7 @@ final class Shortcode_Tag extends Tag {
      *
      * @return string
      */
-    public function get_title() {
+    public function get_title(): string {
         return esc_html__( 'Anything Shortcodes', 'anys' );
     }
 
@@ -38,7 +38,7 @@ final class Shortcode_Tag extends Tag {
      *
      * @return string
      */
-    public function get_group() {
+    public function get_group(): string {
         return 'anything-shortcodes';
     }
 
@@ -47,7 +47,7 @@ final class Shortcode_Tag extends Tag {
      *
      * @return array
      */
-    public function get_categories() {
+    public function get_categories(): array {
         return [ Dynamic_Tags_Module::TEXT_CATEGORY ];
     }
 
@@ -56,7 +56,7 @@ final class Shortcode_Tag extends Tag {
      *
      * @return void
      */
-    protected function register_controls() {
+    protected function register_controls(): void {
         $this->add_control(
             'anys_shortcode',
             [
@@ -74,7 +74,7 @@ final class Shortcode_Tag extends Tag {
      *
      * @return void
      */
-    public function render() {
+    public function render(): void {
         $raw = trim( (string) $this->get_settings( 'anys_shortcode' ) );
 
         // Skips empty or invalid shortcode.

--- a/includes/modules/nav-menu/nav-menu.php
+++ b/includes/modules/nav-menu/nav-menu.php
@@ -21,7 +21,7 @@ final class Nav_Menu {
      *
      * @since 1.4.0
      */
-    protected function add_hooks() {
+    protected function add_hooks(): void {
         add_filter( 'wp_nav_menu_objects', [ $this, 'process_menu_shortcodes' ] );
 
         // Temporarily disabled admin preview — until further decision.
@@ -37,7 +37,7 @@ final class Nav_Menu {
      *
      * @return array
      */
-    public function process_menu_shortcodes( $items ) {
+    public function process_menu_shortcodes( array $items ): array {
         foreach ( $items as $item ) {
             if ( ! is_object( $item ) ) {
                 continue;
@@ -76,7 +76,7 @@ final class Nav_Menu {
      * @param int     $depth
      * @param array   $args
      */
-    public function admin_menu_item_preview( $item_id, $item, $depth, $args ) {
+    public function admin_menu_item_preview( int $item_id, \WP_Post $item, int $depth, array $args ): void {
         if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
             return;
         }

--- a/includes/modules/shortcodes/shortcodes.php
+++ b/includes/modules/shortcodes/shortcodes.php
@@ -22,7 +22,7 @@ final class Shortcodes {
      *
      * @since 1.0.0
      */
-    protected function add_hooks() {
+    protected function add_hooks(): void {
         add_action( 'init', [ $this, 'register_shortcode' ] );
     }
 
@@ -31,7 +31,7 @@ final class Shortcodes {
      *
      * @since 1.0.0
      */
-    public function register_shortcode() {
+    public function register_shortcode(): void {
         // Requires the Base class before registering the shortcode.
         $base_file = ANYS_MODULES_PATH . 'shortcodes/types/base.php';
 
@@ -47,12 +47,12 @@ final class Shortcodes {
      *
      * @since 1.0.0
      *
-     * @param array  $attributes Shortcode attributes.
-     * @param string $content    Shortcode content.
+     * @param array<string,mixed> $attributes Shortcode attributes.
+     * @param string|null         $content    Shortcode content.
      *
-     * @return string
+     * @return string Final rendered output.
      */
-    public function render_shortcode( array $attributes, string $content = '' ) {
+    public function render_shortcode( array $attributes, ?string $content = '' ): string {
         /**
          * Filters the shortcode attributes before processing.
          *
@@ -120,7 +120,11 @@ final class Shortcodes {
         require_once $file;
 
         // Build the class name based on the file type.
-        $class_name = '\\AnyS\\Modules\\Shortcodes\\Types\\' . str_replace( '-', '_', ucfirst( $attributes['type'] ) . '_Type' );
+        $class_name = '\\AnyS\\Modules\\Shortcodes\\Types\\' . str_replace(
+            '-',
+            '_',
+            ucfirst( $attributes['type'] ) . '_Type'
+        );
 
         // Check if the class exists before calling render().
         if ( ! class_exists( $class_name ) ) {
@@ -190,8 +194,8 @@ final class Shortcodes {
             $content
         );
 
-        // Returns the final output.
-        return $output;
+        // Returns the final output as string.
+        return (string) $output;
     }
 }
 

--- a/includes/modules/shortcodes/types/base.php
+++ b/includes/modules/shortcodes/types/base.php
@@ -20,16 +20,16 @@ abstract class Base {
      *
      * @return string
      */
-    abstract public function get_type();
+    abstract public function get_type(): string;
 
     /**
      * Returns the default shortcode attributes.
      *
      * @since NEXT
      *
-     * @return array
+     * @return array<string,mixed>
      */
-    protected function get_defaults() {
+    protected function get_defaults(): array {
         return [];
     }
 
@@ -38,11 +38,11 @@ abstract class Base {
      *
      * @since NEXT
      *
-     * @param array $attributes Raw attributes.
+     * @param array<string,mixed> $attributes Raw attributes.
      *
-     * @return array Merged attributes.
+     * @return array<string,mixed> Merged attributes.
      */
-    protected function get_attributes( array $attributes ) {
+    protected function get_attributes( array $attributes ): array {
         $defaults = $this->get_defaults();
 
         $attributes = wp_parse_args(
@@ -63,5 +63,5 @@ abstract class Base {
      *
      * @return string
      */
-    abstract public function render( array $attributes, string $content );
+    abstract public function render( array $attributes, string $content ): string;
 }

--- a/includes/modules/shortcodes/types/function.php
+++ b/includes/modules/shortcodes/types/function.php
@@ -23,7 +23,7 @@ final class Function_Type extends Base {
      *
      * @return string
      */
-    public function get_type() {
+    public function get_type(): string {
         return 'function';
     }
 
@@ -32,9 +32,9 @@ final class Function_Type extends Base {
      *
      * @since NEXT
      *
-     * @return array
+     * @return array<string,mixed>
      */
-    protected function get_defaults() {
+    protected function get_defaults(): array {
         return [
             'name'     => '',
             'before'   => '',
@@ -50,12 +50,12 @@ final class Function_Type extends Base {
      * @since 1.1.0
      * @since NEXT Moved to class-based structure.
      *
-     * @param array  $attributes Shortcode attributes.
-     * @param string $content    Enclosed content (optional).
+     * @param array<string,mixed> $attributes Shortcode attributes.
+     * @param string|null         $content    Enclosed content (optional).
      *
      * @return string
      */
-    public function render( array $attributes, string $content ) {
+    public function render( array $attributes, ?string $content = '' ): string {
         $attributes = $this->get_attributes( $attributes );
 
         // Parses dynamic attributes.
@@ -70,7 +70,7 @@ final class Function_Type extends Base {
             return '';
         }
 
-        // Validates function existence
+        // Validates function existence.
         if ( ! function_exists( $function ) ) {
             if ( current_user_can( 'manage_options' ) ) {
                 return sprintf(
@@ -104,8 +104,9 @@ final class Function_Type extends Base {
         // Resolves arguments.
         $tokens = $args_raw !== '' ? array_map( 'trim', explode( '|', $args_raw ) ) : [];
         $cache  = [];
-        $args   = array_map(
-            static function ( $t ) use ( &$cache ) {
+
+        $args = array_map(
+            static function ( string $t ) use ( &$cache ): mixed {
                 return anys_parse_dynamic_value( $t, $cache );
             },
             $tokens
@@ -115,14 +116,16 @@ final class Function_Type extends Base {
         $args = array_values(
             array_filter(
                 $args,
-                static function ( $a ) { return $a !== ''; }
+                static function ( mixed $a ): bool {
+                    return $a !== '';
+                }
             )
         );
 
         try {
             // Executes target function.
             $value = call_user_func_array( $function, $args );
-        } catch ( \Throwable ) {
+        } catch ( \Throwable $e ) {
             $value = '';
         }
 

--- a/includes/modules/shortcodes/types/link.php
+++ b/includes/modules/shortcodes/types/link.php
@@ -23,7 +23,7 @@ final class Link_Type extends Base {
      *
      * @return string
      */
-    public function get_type() {
+    public function get_type(): string {
         return 'link';
     }
 
@@ -32,9 +32,9 @@ final class Link_Type extends Base {
      *
      * @since NEXT
      *
-     * @return array
+     * @return array<string,mixed>
      */
-    protected function get_defaults() {
+    protected function get_defaults(): array {
         return [
             'name'             => '',
             'id'               => 0,
@@ -57,12 +57,12 @@ final class Link_Type extends Base {
      * @since 1.3.0
      * @since NEXT Moved to class-based structure.
      *
-     * @param array  $attributes Shortcode attributes.
-     * @param string $content    Enclosed content (optional).
+     * @param array<string,mixed> $attributes Shortcode attributes.
+     * @param string|null         $content    Enclosed content (optional).
      *
      * @return string
      */
-    public function render( array $attributes, string $content = '' ) {
+    public function render( array $attributes, ?string $content = '' ): string {
         $attributes = $this->get_attributes( $attributes );
 
         // Parses dynamic attributes.
@@ -72,21 +72,28 @@ final class Link_Type extends Base {
         $format = $attributes['format'] ?? 'raw';
         $target = $attributes['target'] ?? '';
 
-        // Define handlers
+        // Define handlers.
+        /** @var array<string,callable> $handlers */
         $handlers = [
-            'logout'   => fn( $atts ) => wp_logout_url( $atts['logout_redirect'] ?? '' ),
-            'login'    => fn( $atts ) => wp_login_url( $atts['login_redirect'] ?? '' ),
-            'register' => fn() => wp_registration_url(),
-            'home'     => fn() => home_url(),
-            'admin'    => fn() => admin_url(),
-            'profile'  => fn() => admin_url( 'profile.php' ),
-            'post'     => fn( $atts ) => empty( $atts['id'] ) ? '' : ( is_wp_error( $p = get_permalink( (int) $atts['id'] ) ) ? '' : $p ),
-            'term'     => fn( $atts ) => empty( $atts['id'] ) ? '' : ( is_wp_error( $t = get_term_link( (int) $atts['id'] ) ) ? '' : $t ),
-            'siteurl'  => fn() => site_url(),
-            'current'  => fn() => home_url( add_query_arg( [] ) ),
-            'auth'     => fn( $atts ) => is_user_logged_in()
-                ? wp_logout_url( $atts['logout_redirect'] ?? '' )
-                : wp_login_url( $atts['login_redirect'] ?? '' ),
+            'logout'   => fn( array $atts ): string =>
+                wp_logout_url( (string) ( $atts['logout_redirect'] ?? '' ) ),
+            'login'    => fn( array $atts ): string =>
+                wp_login_url( (string) ( $atts['login_redirect'] ?? '' ) ),
+            'register' => fn(): string => wp_registration_url(),
+            'home'     => fn(): string => home_url(),
+            'admin'    => fn(): string => admin_url(),
+            'profile'  => fn(): string => admin_url( 'profile.php' ),
+            'post'     => fn( array $atts ): string => empty( $atts['id'] )
+                ? ''
+                : ( is_wp_error( $p = get_permalink( (int) $atts['id'] ) ) ? '' : (string) $p ),
+            'term'     => fn( array $atts ): string => empty( $atts['id'] )
+                ? ''
+                : ( is_wp_error( $t = get_term_link( (int) $atts['id'] ) ) ? '' : (string) $t ),
+            'siteurl'  => fn(): string => site_url(),
+            'current'  => fn(): string => home_url( add_query_arg( [] ) ),
+            'auth'     => fn( array $atts ): string => is_user_logged_in()
+                ? wp_logout_url( (string) ( $atts['logout_redirect'] ?? '' ) )
+                : wp_login_url( (string) ( $atts['login_redirect'] ?? '' ) ),
         ];
 
         /**
@@ -94,14 +101,16 @@ final class Link_Type extends Base {
          *
          * @since 1.3.0
          *
-         * @param array $handlers The list of available link handlers.
+         * @param array<string,callable> $handlers The list of available link handlers.
          *
-         * @return array Modified list of link handlers.
+         * @return array<string,callable> Modified list of link handlers.
          */
         $handlers = apply_filters( 'anys/link/handlers', $handlers );
 
         // Resolves URL.
-        $url   = isset( $handlers[ $name ] ) ? call_user_func( $handlers[ $name ], $attributes ) : '';
+        $url   = isset( $handlers[ $name ] )
+            ? (string) call_user_func( $handlers[ $name ], $attributes )
+            : '';
         $label = $attributes['label'] ?: ucfirst( $name );
 
         // Adjusts label for auth.
@@ -115,13 +124,18 @@ final class Link_Type extends Base {
 
         // Builds anchor.
         if ( $format === 'anchor' ) {
-            $t = $target ? sprintf( ' target="%s"', esc_attr( $target ) ) : '';
-            $value = sprintf( '<a href="%s"%s class="anys-link">%s</a>', esc_url( $url ), $t, esc_html( $label ) );
+            $t     = $target ? sprintf( ' target="%s"', esc_attr( $target ) ) : '';
+            $value = sprintf(
+                '<a href="%s"%s class="anys-link">%s</a>',
+                esc_url( $url ),
+                $t,
+                esc_html( $label )
+            );
         }
 
         // Wraps and returns.
         $output = anys_wrap_output( $value, $attributes );
 
-        return wp_kses_post( $output );
+        return wp_kses_post( (string) $output );
     }
 }

--- a/includes/modules/shortcodes/types/option.php
+++ b/includes/modules/shortcodes/types/option.php
@@ -23,7 +23,7 @@ final class Option_Type extends Base {
      *
      * @return string
      */
-    public function get_type() {
+    public function get_type(): string {
         return 'option';
     }
 
@@ -32,9 +32,9 @@ final class Option_Type extends Base {
      *
      * @since NEXT
      *
-     * @return array
+     * @return array<string,mixed>
      */
-    protected function get_defaults() {
+    protected function get_defaults(): array {
         return [
             'name'     => '',
             'before'   => '',
@@ -50,12 +50,12 @@ final class Option_Type extends Base {
      * @since 1.0.0
      * @since NEXT Moved to class-based structure.
      *
-     * @param array  $attributes Shortcode attributes.
-     * @param string $content    Enclosed content (optional).
+     * @param array<string,mixed> $attributes Shortcode attributes.
+     * @param string|null         $content    Enclosed content (optional).
      *
      * @return string
      */
-    public function render( array $attributes, string $content = '' ) {
+    public function render( array $attributes, ?string $content = '' ): string {
         $attributes = $this->get_attributes( $attributes );
 
         // Parses dynamic attributes.

--- a/includes/modules/shortcodes/types/post-meta.php
+++ b/includes/modules/shortcodes/types/post-meta.php
@@ -23,7 +23,7 @@ final class Post_Meta_Type extends Base {
      *
      * @return string
      */
-    public function get_type() {
+    public function get_type(): string {
         return 'post-meta';
     }
 
@@ -32,9 +32,9 @@ final class Post_Meta_Type extends Base {
      *
      * @since NEXT
      *
-     * @return array
+     * @return array<string,mixed>
      */
-    protected function get_defaults() {
+    protected function get_defaults(): array {
         return [
             'id'       => get_the_ID(),
             'name'     => '',
@@ -51,19 +51,19 @@ final class Post_Meta_Type extends Base {
      * @since 1.0.0
      * @since NEXT Moved to class-based structure.
      *
-     * @param array  $attributes Shortcode attributes.
-     * @param string $content    Enclosed content (optional).
+     * @param array<string,mixed> $attributes Shortcode attributes.
+     * @param string|null         $content    Enclosed content (optional).
      *
      * @return string
      */
-    public function render( array $attributes, string $content ) {
+    public function render( array $attributes, ?string $content = '' ): string {
         $attributes = $this->get_attributes( $attributes );
 
         // Parses dynamic attributes.
         $attributes = anys_parse_dynamic_attributes( $attributes );
 
-        $key     = $attributes['name'] ?? '';
-        $post_id = (int) $attributes['id'];
+        $key     = isset( $attributes['name'] ) ? (string) $attributes['name'] : '';
+        $post_id = isset( $attributes['id'] ) ? (int) $attributes['id'] : 0;
 
         if ( $key === '' || $post_id <= 0 ) {
             return '';

--- a/includes/modules/shortcodes/types/spoiler.php
+++ b/includes/modules/shortcodes/types/spoiler.php
@@ -23,7 +23,7 @@ final class Spoiler_Type extends Base {
      *
      * @return string
      */
-    public function get_type() {
+    public function get_type(): string {
         return 'spoiler';
     }
 
@@ -34,23 +34,23 @@ final class Spoiler_Type extends Base {
      *
      * @since NEXT
      *
-     * @return array
+     * @return array<string,mixed>
      */
-    protected function get_defaults() {
+    protected function get_defaults(): array {
         return [
-            'before' => '',
-            'after' => '',
-            'fallback' => '',
-            'format' => '',
-            'scale' => '',
-            'min-velocity' => '',
-            'max-velocity' => '',
+            'before'            => '',
+            'after'             => '',
+            'fallback'          => '',
+            'format'            => '',
+            'scale'             => '',
+            'min-velocity'      => '',
+            'max-velocity'      => '',
             'particle-lifetime' => '',
-            'density' => '',
-            'reveal-duration' => '',
-            'spawn-stop-delay' => '',
-            'monitor-position' => '',
-            'fps' => '',
+            'density'           => '',
+            'reveal-duration'   => '',
+            'spawn-stop-delay'  => '',
+            'monitor-position'  => '',
+            'fps'               => '',
         ];
     }
 
@@ -59,12 +59,12 @@ final class Spoiler_Type extends Base {
      *
      * @since NEXT
      *
-     * @param array  $attributes Raw shortcode attributes.
-     * @param string $content    Shortcode content.
+     * @param array<string,mixed> $attributes Raw shortcode attributes.
+     * @param string|null         $content    Shortcode content.
      *
      * @return string
      */
-    public function render( array $attributes, string $content = '' ) {
+    public function render( array $attributes, ?string $content = '' ): string {
         $attributes = $this->get_attributes( $attributes );
         $attributes = anys_parse_dynamic_attributes( $attributes );
 
@@ -101,7 +101,7 @@ final class Spoiler_Type extends Base {
         }
 
         // Processes content.
-        $inner = wp_kses_post( do_shortcode( $content ) );
+        $inner = wp_kses_post( do_shortcode( (string) ( $content ?? '' ) ) );
 
         // Creates <spoiler-span> element.
         $spoiler = sprintf(
@@ -112,20 +112,20 @@ final class Spoiler_Type extends Base {
 
         // Applies wrappers and formatting.
         $spoiler = anys_format_value( $spoiler, $attributes );
-        $output = anys_wrap_output( $spoiler, $attributes );
+        $output  = anys_wrap_output( $spoiler, $attributes );
 
         // Allows spoiler-span attributes.
         $allowed = wp_kses_allowed_html( 'post' );
         $allowed['spoiler-span'] = [
-            'scale' => true,
-            'min-velocity' => true,
-            'max-velocity' => true,
+            'scale'             => true,
+            'min-velocity'      => true,
+            'max-velocity'      => true,
             'particle-lifetime' => true,
-            'density' => true,
-            'reveal-duration' => true,
-            'spawn-stop-delay' => true,
-            'monitor-position' => true,
-            'fps' => true,
+            'density'           => true,
+            'reveal-duration'   => true,
+            'spawn-stop-delay'  => true,
+            'monitor-position'  => true,
+            'fps'               => true,
         ];
 
         return wp_kses( (string) $output, $allowed );

--- a/includes/modules/shortcodes/types/term-field.php
+++ b/includes/modules/shortcodes/types/term-field.php
@@ -23,7 +23,7 @@ final class Term_Field_Type extends Base {
      *
      * @return string
      */
-    public function get_type() {
+    public function get_type(): string {
         return 'term-field';
     }
 
@@ -32,9 +32,9 @@ final class Term_Field_Type extends Base {
      *
      * @since NEXT
      *
-     * @return array
+     * @return array<string,mixed>
      */
-    protected function get_defaults() {
+    protected function get_defaults(): array {
         return [
             'id'       => 0,
             'name'     => '',
@@ -52,25 +52,25 @@ final class Term_Field_Type extends Base {
      * @since 1.2.0
      * @since NEXT Moved to class-based structure.
      *
-     * @param array  $attributes Shortcode attributes.
-     * @param string $content    Enclosed content (optional).
+     * @param array<string,mixed> $attributes Shortcode attributes.
+     * @param string|null         $content    Enclosed content (optional).
      *
      * @return string
      */
-    public function render( array $attributes, string $content ) {
+    public function render( array $attributes, ?string $content = '' ): string {
         $attributes = $this->get_attributes( $attributes );
 
         // Parses dynamic attributes.
         $attributes = anys_parse_dynamic_attributes( $attributes );
 
-        $term_field_name = $attributes['name'] ?? '';
-        $term_id         = (int) ( $attributes['id'] ?? 0 );
-        $taxonomy_name   = $attributes['taxonomy'] ?? '';
+        $term_field_name = isset( $attributes['name'] ) ? (string) $attributes['name'] : '';
+        $term_id         = isset( $attributes['id'] ) ? (int) $attributes['id'] : 0;
+        $taxonomy_name   = isset( $attributes['taxonomy'] ) ? (string) $attributes['taxonomy'] : '';
 
-        // Try to get current queried term if ID not provided
+        // Try to get current queried term if ID not provided.
         if ( $term_id <= 0 && is_tax() ) {
             $queried_object = get_queried_object();
-            if ( isset( $queried_object->term_id ) ) {
+            if ( $queried_object && isset( $queried_object->term_id ) ) {
                 $term_id       = (int) $queried_object->term_id;
                 $taxonomy_name = $queried_object->taxonomy ?? $taxonomy_name;
             }
@@ -81,9 +81,9 @@ final class Term_Field_Type extends Base {
         }
 
         // Fetches the term.
-        $term  = get_term( $term_id, $taxonomy_name );
-        $value = ( $term && ! is_wp_error( $term ) && isset( $term->$term_field_name ) )
-            ? $term->$term_field_name
+        $term = get_term( $term_id, $taxonomy_name );
+        $value = ( $term && ! is_wp_error( $term ) && isset( $term->{$term_field_name} ) )
+            ? $term->{$term_field_name}
             : '';
 
         // Formats and wraps.

--- a/includes/modules/shortcodes/types/user-field.php
+++ b/includes/modules/shortcodes/types/user-field.php
@@ -23,7 +23,7 @@ final class User_Field_Type extends Base {
      *
      * @return string
      */
-    public function get_type() {
+    public function get_type(): string {
         return 'user-field';
     }
 
@@ -32,9 +32,9 @@ final class User_Field_Type extends Base {
      *
      * @since NEXT
      *
-     * @return array
+     * @return array<string,mixed>
      */
-    protected function get_defaults() {
+    protected function get_defaults(): array {
         return [
             'id'       => get_current_user_id(),
             'name'     => '',
@@ -51,19 +51,19 @@ final class User_Field_Type extends Base {
      * @since 1.0.0
      * @since NEXT Moved to class-based structure.
      *
-     * @param array  $attributes Shortcode attributes.
-     * @param string $content    Enclosed content (optional).
+     * @param array<string,mixed> $attributes Shortcode attributes.
+     * @param string|null         $content    Enclosed content (optional).
      *
      * @return string
      */
-    public function render( array $attributes, string $content ) {
+    public function render( array $attributes, ?string $content = '' ): string {
         $attributes = $this->get_attributes( $attributes );
 
         // Parses dynamic attributes.
         $attributes = anys_parse_dynamic_attributes( $attributes );
 
-        $key     = $attributes['name'] ?? '';
-        $user_id = (int) $attributes['id'];
+        $key     = isset( $attributes['name'] ) ? (string) $attributes['name'] : '';
+        $user_id = isset( $attributes['id'] ) ? (int) $attributes['id'] : 0;
 
         if ( $key === '' || $user_id <= 0 ) {
             return '';
@@ -71,7 +71,7 @@ final class User_Field_Type extends Base {
 
         // Fetches user and field.
         $user  = get_userdata( $user_id );
-        $value = ( $user && isset( $user->$key ) ) ? $user->$key : '';
+        $value = ( $user && isset( $user->{$key} ) ) ? $user->{$key} : '';
 
         // Formats and wraps.
         $value  = anys_format_value( $value, $attributes );

--- a/includes/modules/shortcodes/types/user-meta.php
+++ b/includes/modules/shortcodes/types/user-meta.php
@@ -23,7 +23,7 @@ final class User_Meta_Type extends Base {
      *
      * @return string
      */
-    public function get_type() {
+    public function get_type(): string {
         return 'user-meta';
     }
 
@@ -32,9 +32,9 @@ final class User_Meta_Type extends Base {
      *
      * @since NEXT
      *
-     * @return array
+     * @return array<string,mixed>
      */
-    protected function get_defaults() {
+    protected function get_defaults(): array {
         return [
             'id'       => get_current_user_id(),
             'name'     => '',
@@ -51,30 +51,30 @@ final class User_Meta_Type extends Base {
      * @since 1.0.0
      * @since NEXT Moved to class-based structure.
      *
-     * @param array  $attributes Shortcode attributes.
-     * @param string $content    Enclosed content (optional).
+     * @param array<string,mixed> $attributes Shortcode attributes.
+     * @param string|null         $content    Enclosed content (optional).
      *
      * @return string
      */
-    public function render( array $attributes, string $content ) {
+    public function render( array $attributes, ?string $content = '' ): string {
         $attributes = $this->get_attributes( $attributes );
 
         // Parses dynamic attributes.
         $attributes = anys_parse_dynamic_attributes( $attributes );
 
-        $user_meta_key = $attributes['name'] ?? '';
-        $user_id       = (int) $attributes['id'];
+        $key     = isset( $attributes['name'] ) ? (string) $attributes['name'] : '';
+        $user_id = isset( $attributes['id'] ) ? (int) $attributes['id'] : 0;
 
-        if ( $user_meta_key === '' || $user_id <= 0 ) {
+        if ( $key === '' || $user_id <= 0 ) {
             return '';
         }
 
         // Fetches user meta.
-        $user_meta_value = get_user_meta( $user_id, $user_meta_key, true );
+        $value = get_user_meta( $user_id, $key, true );
 
         // Formats and wraps.
-        $formatted_value = anys_format_value( $user_meta_value, $attributes );
-        $output          = anys_wrap_output( $formatted_value, $attributes );
+        $value  = anys_format_value( $value, $attributes );
+        $output = anys_wrap_output( $value, $attributes );
 
         return wp_kses_post( (string) $output );
     }

--- a/includes/modules/utilities.php
+++ b/includes/modules/utilities.php
@@ -16,7 +16,7 @@
  *
  * @return string Returns if the value is found; else $default is returned.
  */
-function anys_get( $needle, $haystack = false, $default = null ) {
+function anys_get( string $needle, array|false|null $haystack = false, mixed $default = null ): mixed {
 
     if ( false === $haystack ) {
         $haystack = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification -- The nonce verification check should be at the form processing level.
@@ -41,7 +41,7 @@ function anys_get( $needle, $haystack = false, $default = null ) {
  *
  * @return string Returns the value if found; else $default is returned.
  */
-function anys_post( $needle, $haystack = false, $default = null ) {
+function anys_post( string $needle, array|false|null $haystack = false, mixed $default = null ): mixed {
 
     if ( false === $haystack ) {
         $haystack = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification -- The nonce verification check should be at the form processing level.
@@ -60,7 +60,7 @@ function anys_post( $needle, $haystack = false, $default = null ) {
  *
  * @return string Returns the value if found; else $default is returned.
  */
-function anys_get_or_post( $needle, $default = null ) {
+function anys_get_or_post( string $needle, mixed $default = null ): mixed {
     $get = anys_get( $needle );
 
     if ( $get ) {
@@ -83,7 +83,7 @@ function anys_get_or_post( $needle, $default = null ) {
  *
  * @return string Returns text with prefix.
  */
-function anys_prefix( $text ) {
+function anys_prefix( string $text ): string {
     return ANYS_SLUG . $text;
 }
 
@@ -95,7 +95,7 @@ function anys_prefix( $text ) {
  *
  * @return mixed|null
  */
-function anys_call_function( $function_name, $args = [] ) {
+function anys_call_function( string $function_name, array $args = [] ): mixed {
     $whitelisted_functions = anys_get_whitelisted_functions();
 
     if ( function_exists( $function_name ) && in_array( $function_name, $whitelisted_functions, true ) ) {
@@ -113,9 +113,10 @@ function anys_call_function( $function_name, $args = [] ) {
  *
  * @param mixed  $value
  * @param string $format
+ *
  * @return string
  */
-function anys_format_value( $value, $attributes = [] ) {
+function anys_format_value( mixed $value, array $attributes = [] ): mixed {
     if ( empty( $attributes['format'] ) ) {
         return $value;
     }
@@ -231,7 +232,7 @@ function anys_format_value( $value, $attributes = [] ) {
  *
  * @return string
  */
-function anys_wrap_output( $value, $attributes = [] ) {
+function anys_wrap_output( mixed $value, array $attributes = [] ): string {
     if ( empty( $value ) && ! empty( $attributes['fallback'] ) ) {
         $value = $attributes['fallback'];
     }
@@ -239,7 +240,7 @@ function anys_wrap_output( $value, $attributes = [] ) {
     $before = $attributes['before'] ?? '';
     $after  = $attributes['after'] ?? '';
 
-    return $before . $value . $after;
+    return $before . (string) $value . $after;
 }
 
 /**
@@ -257,7 +258,7 @@ function anys_wrap_output( $value, $attributes = [] ) {
  *
  * @return string|array
  */
-function anys_parse_dynamic_value( $value, &$cache = [] ) {
+function anys_parse_dynamic_value( mixed $value, array &$cache = [] ): mixed {
     if ( is_array( $value ) ) {
         foreach ( $value as $k => $v ) {
             $value[ $k ] = anys_parse_dynamic_value( $v, $cache );
@@ -358,7 +359,7 @@ function anys_parse_dynamic_value( $value, &$cache = [] ) {
  *
  * @return array
  */
-function anys_parse_dynamic_attributes( $atts ) {
+function anys_parse_dynamic_attributes( $atts ): array {
     $cache = [];
 
     foreach ( $atts as $key => $value ) {
@@ -375,7 +376,7 @@ function anys_parse_dynamic_attributes( $atts ) {
  *
  * @return array The list of whitelisted function names.
  */
-function anys_get_whitelisted_functions() {
+function anys_get_whitelisted_functions(): array {
     // Default whitelisted functions.
     $default_functions = anys_get_default_whitelisted_functions();
 
@@ -401,7 +402,7 @@ function anys_get_whitelisted_functions() {
  *
  * @return array The list of default whitelisted function names.
  */
-function anys_get_default_whitelisted_functions() {
+function anys_get_default_whitelisted_functions(): mixed {
     $default_functions = [
         'abs',
         'ceil',
@@ -467,7 +468,7 @@ function anys_get_default_whitelisted_functions() {
  *
  * @return string Modified shortcode string.
  */
-function anys_force_shortcode_attr( $shortcode, $attr, $value ) {
+function anys_force_shortcode_attr( string $shortcode, string $attr, string $value ): string {
     $shortcode = (string) $shortcode;
 
     // Replaces existing attribute.
@@ -494,7 +495,7 @@ function anys_force_shortcode_attr( $shortcode, $attr, $value ) {
  *
  * @return bool True if any shortcode exists, false otherwise.
  */
-function anys_has_shortcode( $content ) {
+function anys_has_shortcode( string $content ): bool {
     if ( preg_match( '/\[[a-zA-Z0-9_]+[^\]]*\]/', $content ) ) {
         return true;
     }
@@ -513,7 +514,7 @@ function anys_has_shortcode( $content ) {
  *
  * @return string
  */
-function anys_date_i18n_jalali( $format, $timestamp = false, $gmt = false ) {
+function anys_date_i18n_jalali( string $format, int|false $timestamp = false, bool $gmt = false ): string {
 
     // Timestamp is resolved like core.
     $resolved_timestamp = ( false === $timestamp )

--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -46,10 +46,10 @@ final class Plugin {
      *
      * @since 1.0.0
      */
-    private function safe_mode() {
+    private function safe_mode(): bool {
         $safe_mode = filter_input( INPUT_GET, 'anys_safe_mode', FILTER_SANITIZE_SPECIAL_CHARS );
 
-        return boolval( $safe_mode );
+        return (bool) $safe_mode;
     }
 
     /**
@@ -58,7 +58,7 @@ final class Plugin {
      * @since 1.0.0
      * @since 1.1.0 Changes Shortcode constant to Types.
      */
-    protected function define_constants() {
+    protected function define_constants(): void {
         define( 'ANYS_NAME', 'Anything Shortcodes' );
         define( 'ANYS_SLUG', 'anys' );
         define( 'ANYS_VERSION', '1.4.0' );
@@ -82,7 +82,7 @@ final class Plugin {
      *
      * @since 1.0.0
      */
-    protected function add_hooks() {
+    protected function add_hooks(): void {
         add_action( 'plugins_loaded', [ $this, 'init' ] );
         add_action( 'init', [ $this, 'load_textdomain' ] );
         add_action( 'anys/init', [ $this, 'load_modules' ] );
@@ -93,7 +93,7 @@ final class Plugin {
      *
      * @since 1.0.0
      */
-    public function init() {
+    public function init(): void {
         /**
          * Loads Anything Shortcodes .
          *
@@ -107,7 +107,7 @@ final class Plugin {
      *
      * @since 1.0.0
      */
-    public function load_textdomain() {
+    public function load_textdomain(): void {
         load_plugin_textdomain( 'anys', false, ANYS_PATH . '/languages' );
     }
 
@@ -120,7 +120,7 @@ final class Plugin {
      *
      * @return void
      */
-    protected function load_file( $file ) {
+    protected function load_file( string $file ): void {
         if (
             ! empty( $file )
             && file_exists( $file )
@@ -136,7 +136,7 @@ final class Plugin {
      * @since 1.1.0 Changes file name.
      * @since 1.4.0 Dynamic includes & Composer support.
      */
-    public function load_modules() {
+    public function load_modules(): void {
         // Loads Composer autoload if available.
         $this->load_file( ANYS_PATH . '/vendor/autoload.php' );
 

--- a/includes/traits/trait-singleton.php
+++ b/includes/traits/trait-singleton.php
@@ -20,7 +20,7 @@ trait Singleton {
      *
      * @var static
      */
-    private static $instance;
+    private static ?self $instance = null;
 
     /**
      * Returns the instance.
@@ -29,7 +29,7 @@ trait Singleton {
      *
      * @return static
      */
-    public static function get_instance() {
+    public static function get_instance(): static {
         if ( is_null( self::$instance ) ) {
             self::$instance = new self();
         }
@@ -52,14 +52,14 @@ trait Singleton {
      *
      * @since NEXT
      */
-    protected function add_hooks() {}
+    protected function add_hooks(): void {}
 
     /**
      * Loads helpers file for the module if it exists.
      *
      * @since NEXT
      */
-    protected function load_helpers() {
+    protected function load_helpers(): void {
         // Gets the module's directory (where the class file is located).
         $reflector    = new \ReflectionClass( $this );
         $dir          = dirname( $reflector->getFileName() );


### PR DESCRIPTION
This PR introduces strict type hinting to all modules in the plugin, improving code clarity, maintainability, and IDE support.

### **Included:**

* Added return/parameter type hints across all classes
* Updated shortcode type handlers with strict signatures
* Improved internal module consistency
* Ensured compatibility with WordPress core functions
